### PR TITLE
optimization(css rendering): merge <style> tags

### DIFF
--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -43,7 +43,8 @@ import {
 	eachPageData,
 	eachPrerenderedPageData,
 	getPageDataByComponent,
-	sortedStylesheets,
+	cssOrder,
+	mergeInlineCss,
 } from './internal.js';
 import type {
 	PageBuildData,
@@ -166,7 +167,10 @@ async function generatePage(
 	// may be used in the future for handling rel=modulepreload, rel=icon, rel=manifest etc.
 	const linkIds: [] = [];
 	const scripts = pageInfo?.hoistedScript ?? null;
-	const styles = sortedStylesheets(pageData);
+	const styles = pageData.styles
+		.sort(cssOrder)
+		.map(({ sheet }) => sheet)
+		.reduce(mergeInlineCss, []);
 
 	const pageModule = ssrEntry.pageMap?.get(pageData.component);
 

--- a/packages/astro/src/core/build/internal.ts
+++ b/packages/astro/src/core/build/internal.ts
@@ -1,5 +1,5 @@
 import type { Rollup } from 'vite';
-import type { PageBuildData, ViteID } from './types';
+import type { PageBuildData, StylesheetAsset, ViteID } from './types';
 
 import type { SSRResult } from '../../@types/astro';
 import type { PageOptions } from '../../vite-plugin-astro/types';
@@ -240,39 +240,54 @@ export function* eachServerPageData(internals: BuildInternals) {
 	}
 }
 
+interface OrderInfo {
+	depth: number;
+	order: number;
+}
+
 /**
  * Sort a page's CSS by depth. A higher depth means that the CSS comes from shared subcomponents.
  * A lower depth means it comes directly from the top-level page.
  * The return of this function is an array of CSS paths, with shared CSS on top
  * and page-level CSS on bottom.
  */
-export function sortedStylesheets(pageData: PageBuildData) {
-	return pageData.styles
-		.sort((a, b) => {
-			let depthA = a.depth,
-				depthB = b.depth,
-				orderA = a.order,
-				orderB = b.order;
+export function cssOrder(a: OrderInfo, b: OrderInfo) {
+	let depthA = a.depth,
+		depthB = b.depth,
+		orderA = a.order,
+		orderB = b.order;
 
-			if (orderA === -1 && orderB >= 0) {
-				return 1;
-			} else if (orderB === -1 && orderA >= 0) {
-				return -1;
-			} else if (orderA > orderB) {
-				return 1;
-			} else if (orderA < orderB) {
-				return -1;
-			} else {
-				if (depthA === -1) {
-					return -1;
-				} else if (depthB === -1) {
-					return 1;
-				} else {
-					return depthA > depthB ? -1 : 1;
-				}
-			}
-		})
-		.map(({ sheet }) => sheet);
+	if (orderA === -1 && orderB >= 0) {
+		return 1;
+	} else if (orderB === -1 && orderA >= 0) {
+		return -1;
+	} else if (orderA > orderB) {
+		return 1;
+	} else if (orderA < orderB) {
+		return -1;
+	} else {
+		if (depthA === -1) {
+			return -1;
+		} else if (depthB === -1) {
+			return 1;
+		} else {
+			return depthA > depthB ? -1 : 1;
+		}
+	}
+}
+
+export function mergeInlineCss(
+	acc: Array<StylesheetAsset>,
+	current: StylesheetAsset
+): Array<StylesheetAsset> {
+	const lastAdded = acc.at(acc.length - 1);
+	const lastWasInline = lastAdded?.type === 'inline';
+	const currentIsInline = current?.type === 'inline';
+	if (lastWasInline && currentIsInline) {
+		const merged = { type: 'inline' as const, content: lastAdded.content + current.content };
+		return [...acc.slice(0, acc.length - 1), merged];
+	}
+	return [...acc, current];
 }
 
 export function isHoistedScript(internals: BuildInternals, id: string): boolean {

--- a/packages/astro/src/core/build/plugins/plugin-css.ts
+++ b/packages/astro/src/core/build/plugins/plugin-css.ts
@@ -250,11 +250,8 @@ function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
 
 				pages.forEach((pageData) => {
 					const orderingInfo = pagesToCss.get(pageData.moduleSpecifier)?.get(stylesheet.fileName);
-					if (orderingInfo === undefined) return;
-					pageData.styles.push({ ...orderingInfo, sheet });
-				});
+					if (orderingInfo !== undefined) return pageData.styles.push({ ...orderingInfo, sheet });
 
-				pages.forEach((pageData) => {
 					const propagatedPaths = pagesToPropagatedCss.get(pageData.moduleSpecifier);
 					if (propagatedPaths === undefined) return;
 					Array.from(propagatedPaths.entries()).forEach(([pageInfoId, css]) => {

--- a/packages/astro/src/core/build/plugins/plugin-ssr.ts
+++ b/packages/astro/src/core/build/plugins/plugin-ssr.ts
@@ -13,7 +13,12 @@ import { joinPaths, prependForwardSlash } from '../../path.js';
 import { serializeRouteData } from '../../routing/index.js';
 import { addRollupInput } from '../add-rollup-input.js';
 import { getOutFile, getOutFolder } from '../common.js';
-import { eachPrerenderedPageData, eachServerPageData, sortedStylesheets } from '../internal.js';
+import {
+	eachPrerenderedPageData,
+	eachServerPageData,
+	cssOrder,
+	mergeInlineCss,
+} from '../internal.js';
 import type { AstroBuildPlugin } from '../plugin';
 
 export const virtualModuleId = '@astrojs-ssr-virtual-entry';
@@ -189,9 +194,12 @@ function buildManifest(
 
 		// may be used in the future for handling rel=modulepreload, rel=icon, rel=manifest etc.
 		const links: [] = [];
-		const styles = sortedStylesheets(pageData).map((s) =>
-			s.type === 'external' ? { ...s, src: prefixAssetPath(s.src) } : s
-		);
+
+		const styles = pageData.styles
+			.sort(cssOrder)
+			.map(({ sheet }) => sheet)
+			.map((s) => (s.type === 'external' ? { ...s, src: prefixAssetPath(s.src) } : s))
+			.reduce(mergeInlineCss, []);
 
 		routes.push({
 			file: '',


### PR DESCRIPTION
Chrome, but not Safari or Firefox, is slower to match rules when they are split across multiple files or style tags. https://nolanlawson.com/2022/06/22/style-scoping-versus-shadow-dom-which-is-fastest/

Having the abiility to inline stylesheets opens us up to this optimization. Ideally, it would extend to propagated styles, but that ended up being a rabbit hole.
